### PR TITLE
Simplify JSON API

### DIFF
--- a/src/main/php/text/json/Format.class.php
+++ b/src/main/php/text/json/Format.class.php
@@ -6,6 +6,7 @@ use lang\IllegalArgumentException;
  * JSON format
  *
  * @test  xp://text.json.unittest.DefaultFormatTest
+ * @test  xp://text.json.unittest.FormatFactoryTest
  */
 abstract class Format extends \lang\Object {
   const ESCAPE_SLASHES = -65;  // ~JSON_UNESCAPED_SLASHES
@@ -32,6 +33,27 @@ abstract class Format extends \lang\Object {
     $this->comma= $comma;
     $this->colon= $colon;
     $this->options= $options;
+  }
+
+  /**
+   * Creates a new dense format
+   *
+   * @param  int $options
+   * @return self
+   */
+  public static function dense($options= 0) {
+    return new DenseFormat($options ?: ~self::ESCAPE_SLASHES);
+  }
+
+  /**
+   * Creates a new wrapped format
+   *
+   * @param  string $indent
+   * @param  int $options
+   * @return self
+   */
+  public static function wrapped($indent= '    ', $options= 0) {
+    return new WrappedFormat($indent, $options ?: ~self::ESCAPE_SLASHES);
   }
 
   /**

--- a/src/main/php/text/json/Format.class.php
+++ b/src/main/php/text/json/Format.class.php
@@ -13,13 +13,12 @@ abstract class Format extends \lang\Object {
   const ESCAPE_UNICODE = -257; // ~JSON_UNESCAPED_UNICODE
   const ESCAPE_ENTITIES = 11;  // JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT
 
-  public static $DEFAULT, $NATURAL;
+  public static $DEFAULT;
   public $comma;
   public $colon;
 
   static function __static() {
     self::$DEFAULT= new DenseFormat();
-    self::$NATURAL= new WrappedFormat('    ', ~self::ESCAPE_SLASHES);
   }
 
   /**

--- a/src/main/php/text/json/Format.class.php
+++ b/src/main/php/text/json/Format.class.php
@@ -5,7 +5,6 @@ use lang\IllegalArgumentException;
 /**
  * JSON format
  *
- * @test  xp://text.json.unittest.DefaultFormatTest
  * @test  xp://text.json.unittest.FormatFactoryTest
  */
 abstract class Format extends \lang\Object {

--- a/src/main/php/text/json/Json.class.php
+++ b/src/main/php/text/json/Json.class.php
@@ -20,18 +20,24 @@ abstract class Json extends \lang\Object {
    * Writes to an output and returns the output
    *
    * @param  var $value
-   * @param  text.json.Output|text.json.Format $arg
-   * @return text.json.Output The given output, or a StringOutput if a format is given
+   * @param  text.json.Output $output
+   * @return text.json.Output The given output
    */
-  public static function write($value, $arg= null) {
-    if ($arg instanceof Format) {
-      $output= new StringOutput($arg);
-    } else if ($arg instanceof Output) {
-      $output= $arg;
-    } else {
-      $output= new StringOutput(Format::$DEFAULT);
-    }
+  public static function write($value, Output $output) {
     $output->write($value);
     return $output;
+  }
+
+  /**
+   * Returns the output as a string
+   *
+   * @param  var $value
+   * @param  text.json.Format $format
+   * @return string
+   */
+  public static function of($value, Format $format= null) {
+    $output= new StringOutput($format ?: Format::$DEFAULT);
+    $output->write($value);
+    return $output->bytes();
   }
 }

--- a/src/main/php/text/json/Json.class.php
+++ b/src/main/php/text/json/Json.class.php
@@ -1,0 +1,37 @@
+<?php namespace text\json;
+
+abstract class Json extends \lang\Object {
+
+  /**
+   * Reads from an input
+   *
+   * @param  string|text.json.Input $input
+   * @return var
+   */
+  public static function read($input) {
+    if ($input instanceof Input) {
+      return $input->read();
+    } else {
+      return (new StringInput($input))->read();
+    }
+  }
+
+  /**
+   * Writes to an output and returns the output
+   *
+   * @param  var $value
+   * @param  text.json.Output|text.json.Format $arg
+   * @return text.json.Output The given output, or a StringOutput if a format is given
+   */
+  public static function write($value, $arg= null) {
+    if ($arg instanceof Format) {
+      $output= new StringOutput($arg);
+    } else if ($arg instanceof Output) {
+      $output= $arg;
+    } else {
+      $output= new StringOutput(Format::$DEFAULT);
+    }
+    $output->write($value);
+    return $output;
+  }
+}

--- a/src/main/php/text/json/Json.class.php
+++ b/src/main/php/text/json/Json.class.php
@@ -1,5 +1,11 @@
 <?php namespace text\json;
 
+/**
+ * Simple entry point class
+ *
+ * @see   https://github.com/xp-forge/json/issues/3
+ * @test  xp://text.json.unittest.JsonTest
+ */
 abstract class Json extends \lang\Object {
 
   /**

--- a/src/test/php/text/json/unittest/FormatFactoryTest.class.php
+++ b/src/test/php/text/json/unittest/FormatFactoryTest.class.php
@@ -8,7 +8,7 @@ class FormatFactoryTest extends \unittest\TestCase {
 
   #[@test]
   public function dense() {
-    $this->assertInstanceOf(DenseFormat::class, Format::dense());
+    $this->assertInstanceOf('text.json.DenseFormat', Format::dense());
   }
 
   #[@test]
@@ -23,7 +23,7 @@ class FormatFactoryTest extends \unittest\TestCase {
 
   #[@test]
   public function wrapped() {
-    $this->assertInstanceOf(WrappedFormat::class, Format::wrapped());
+    $this->assertInstanceOf('text.json.WrappedFormat', Format::wrapped());
   }
 
   #[@test]

--- a/src/test/php/text/json/unittest/FormatFactoryTest.class.php
+++ b/src/test/php/text/json/unittest/FormatFactoryTest.class.php
@@ -1,0 +1,48 @@
+<?php namespace text\json\unittest;
+
+use text\json\Format;
+use text\json\DenseFormat;
+use text\json\WrappedFormat;
+
+class FormatFactoryTest extends \unittest\TestCase {
+
+  #[@test]
+  public function dense() {
+    $this->assertInstanceOf(DenseFormat::class, Format::dense());
+  }
+
+  #[@test]
+  public function dense_without_options() {
+    $this->assertEquals('"http://example.com/"', Format::dense()->representationOf('http://example.com/'));
+  }
+
+  #[@test]
+  public function dense_with_options() {
+    $this->assertEquals('"http:\/\/example.com\/"', Format::dense(Format::ESCAPE_SLASHES)->representationOf('http://example.com/'));
+  }
+
+  #[@test]
+  public function wrapped() {
+    $this->assertInstanceOf(WrappedFormat::class, Format::wrapped());
+  }
+
+  #[@test]
+  public function wrapped_without_indent() {
+    $this->assertEquals("{\n    \"key\": \"value\"\n}", Format::wrapped()->representationOf(['key' => 'value']));
+  }
+
+  #[@test]
+  public function wrapped_with_indent() {
+    $this->assertEquals("{\n  \"key\": \"value\"\n}", Format::wrapped('  ')->representationOf(['key' => 'value']));
+  }
+
+  #[@test]
+  public function wrapped_without_options() {
+    $this->assertEquals('"http://example.com/"', Format::wrapped('  ')->representationOf('http://example.com/'));
+  }
+
+  #[@test]
+  public function wrapped_with_options() {
+    $this->assertEquals('"http:\/\/example.com\/"', Format::wrapped('  ', Format::ESCAPE_SLASHES)->representationOf('http://example.com/'));
+  }
+}

--- a/src/test/php/text/json/unittest/JsonTest.class.php
+++ b/src/test/php/text/json/unittest/JsonTest.class.php
@@ -34,17 +34,12 @@ class JsonTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function write_string() {
-    $this->assertEquals('"Test"', Json::write('Test')->bytes());
+  public function of_string() {
+    $this->assertEquals('"Test"', Json::of('Test'));
   }
 
   #[@test]
-  public function write_output_with_format() {
-    $this->assertEquals('"Test"', Json::write('Test', new StringOutput(Format::$DEFAULT))->bytes());
-  }
-
-  #[@test]
-  public function write_string_with_format() {
-    $this->assertEquals('"Test"', Json::write('Test', Format::$DEFAULT)->bytes());
+  public function of_string_with_format() {
+    $this->assertEquals('"Test"', Json::of('Test', Format::$DEFAULT));
   }
 }

--- a/src/test/php/text/json/unittest/JsonTest.class.php
+++ b/src/test/php/text/json/unittest/JsonTest.class.php
@@ -1,0 +1,50 @@
+<?php namespace text\json\unittest;
+
+use text\json\Json;
+use text\json\Format;
+use text\json\StringInput;
+use text\json\StringOutput;
+use lang\FormatException;
+
+class JsonTest extends \unittest\TestCase {
+
+  #[@test]
+  public function read_input() {
+    $this->assertEquals('Test', Json::read(new StringInput('"Test"')));
+  }
+
+  #[@test]
+  public function read_string() {
+    $this->assertEquals('Test', Json::read('"Test"'));
+  }
+
+  #[@test, @expect(FormatException::class)]
+  public function read_malformed_string() {
+    Json::read('this.is.not.json');
+  }
+
+  #[@test, @expect(FormatException::class)]
+  public function read_malformed_input() {
+    Json::read(new StringInput('this.is.not.json'));
+  }
+
+  #[@test]
+  public function write_output() {
+    $this->assertEquals('"Test"', Json::write('Test', new StringOutput())->bytes());
+  }
+
+  #[@test]
+  public function write_string() {
+    $this->assertEquals('"Test"', Json::write('Test')->bytes());
+  }
+
+  #[@test]
+  public function write_output_with_format() {
+    $this->assertEquals('"Test"', Json::write('Test', new StringOutput(Format::$DEFAULT))->bytes());
+  }
+
+  #[@test]
+  public function write_string_with_format() {
+    $this->assertEquals('"Test"', Json::write('Test', Format::$DEFAULT)->bytes());
+  }
+}


### PR DESCRIPTION
New simplified API, which works on top of the current one. Less flexible but shorter for the default case!
## API

``` php
public abstract class text.json.Json extends lang.Object {
  public static var read(string|text.json.Input $input)
  public static text.json.Output write(var $value, [text.json.Output|text.json.Format $arg= null])
}

public abstract class text.json.Format extends lang.Object {
  const ESCAPE_SLASHES
  const ESCAPE_UNICODE
  const ESCAPE_ENTITIES

  public static self dense([int $options= 0])
  public static self wrapped([string $indent= "    "], [int $options= 0])
}
```
## Usage

``` php
// Reading
$value= Json::read('"Test"');
$value= Json::read(new StringInput('"Test"'));

// Writing
$output= Json::write('Test', new StringOutput());
$json= $output->bytes();

$output= Json::write('Test', new FileOutput('test.json'));
$file= $output->file();

// Serializing
$json= Json::of('Test');
$json= Json::of('Test', Format::wrapped('  '));
```
## Notes

This will bump the version to 1.0
