### PR TITLE
Refactor: Drop PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,13 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-  - nightly
-
-matrix:
-  allow_failures:
-    - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.6.1/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "~6.0",
-    "php" : ">=5.4.0"
+    "php" : ">=5.5.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]


### PR DESCRIPTION
This drops PHP 5.4 compatiblity by migrating the code base to use PHP 5.5 syntax where applicable.

According to http://seld.be/notes/php-versions-stats-2015-edition, PHP < 5.5 is only used by 26%, while PHP 5.5 is at 51% and PHP 5.6 has been adopted by 22%.
