### PR TITLE
Fix unicode surrogate pairs not being handled correctly

### DIFF
--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -48,7 +48,7 @@ abstract class Input extends \lang\Object {
    * @throws lang.FormatException
    */
   protected function escaped($pos, &$offset) {
-    static $SURROGATE_OFFSET= 0x10000 - (0xD800 << 10) - 0xDC00;
+    static $SURROGATE_OFFSET= 0xfca02400; // 0x10000 - (0xd800 << 10) - 0xdc00;
 
     $escape= $this->bytes{$pos + 1};
     if (isset(self::$escapes[$escape])) {
@@ -56,7 +56,7 @@ abstract class Input extends \lang\Object {
       return self::$escapes[$escape];
     } else if ('u' === $escape) {
       $hex= hexdec(substr($this->bytes, $pos + 2, 4));
-      if ($hex > 0xD800 && $hex < 0xDFFF) {
+      if ($hex > 0xd800 && $hex < 0xdfff) {
         $offset= 12;
         $surrogate= hexdec(substr($this->bytes, $pos + 8, 4));
         $char= ($hex << 10) + $surrogate + $SURROGATE_OFFSET;

--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -48,8 +48,6 @@ abstract class Input extends \lang\Object {
    * @throws lang.FormatException
    */
   protected function escaped($pos, &$offset) {
-    static $SURROGATE_OFFSET= 0xfca02400; // 0x10000 - (0xd800 << 10) - 0xdc00;
-
     $escape= $this->bytes{$pos + 1};
     if (isset(self::$escapes[$escape])) {
       $offset= 2;
@@ -59,7 +57,7 @@ abstract class Input extends \lang\Object {
       if ($hex > 0xd800 && $hex < 0xdfff) {
         $offset= 12;
         $surrogate= hexdec(substr($this->bytes, $pos + 8, 4));
-        $char= ($hex << 10) + $surrogate + $SURROGATE_OFFSET;
+        $char= ($hex << 10) + $surrogate + 0xfca02400;  // surrogate offset: 0x10000 - (0xd800 << 10) - 0xdc00
         return iconv('ucs-4be', $this->encoding, pack('N', $char));
       } else {
         $offset= 6;

--- a/src/main/php/text/json/StreamOutput.class.php
+++ b/src/main/php/text/json/StreamOutput.class.php
@@ -6,7 +6,7 @@ use io\streams\OutputStream;
  * Writes JSON to a given output stream
  *
  * ```php
- * $json= new StreamOutput((new stream('output.json'))->getOutputStream()));
+ * $json= new StreamOutput((new File('output.json'))->out()));
  * $json->write('Hello World');
  * ```
  *

--- a/src/test/php/text/json/unittest/JsonInputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonInputTest.class.php
@@ -42,8 +42,6 @@ abstract class JsonInputTest extends \unittest\TestCase {
   #  ['Test', '"Test"'],
   #  ['Test the "west"', '"Test the \"west\""'],
   #  ['Test "the" west', '"Test \"the\" west"'],
-  #  ['€uro', '"\u20acuro"'], ['€uro', '"\u20ACuro"'],
-  #  ['Knüper', '"Knüper"'], ['Knüper', '"Kn\u00fcper"'],
   #  ["Test\x08", '"Test\b"'],
   #  ["Test\x0c", '"Test\f"'],
   #  ["Test\x0a", '"Test\n"'],
@@ -54,6 +52,15 @@ abstract class JsonInputTest extends \unittest\TestCase {
   #  ["Test/", '"Test\/"']
   #])]
   public function read_string($expected, $source) {
+    $this->assertEquals($expected, $this->read($source));
+  }
+
+  #[@test, @values([
+  #  ['€uro', '"\u20acuro"'], ['€uro', '"\u20ACuro"'], ['€uro', '"€uro"'],
+  #  ['Übercoder', '"\u00dcbercoder"'], ['Übercoder', '"\u00DCbercoder"'], ['Übercoder', '"Übercoder"'],
+  #  ['Poop = 💩', '"Poop = \ud83d\udca9"']
+  #])]
+  public function read_unicode($expected, $source) {
     $this->assertEquals($expected, $this->read($source));
   }
 
@@ -77,7 +84,7 @@ abstract class JsonInputTest extends \unittest\TestCase {
     $this->assertEquals('ü€', $this->read("\"\xfc\u20ac\"", 'iso-8859-15'));
   }
 
-  #[@test, @expect(class= FormatException::class, withMessage= 'Unclosed string'), @values([
+  #[@test, @expect(class= FormatException::class, withMessage= '/Unclosed string/'), @values([
   #  '"', '"abc', '"abc\"'
   #])]
   public function unclosed_string($source) {

--- a/src/test/php/text/json/unittest/JsonOutputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonOutputTest.class.php
@@ -47,7 +47,6 @@ abstract class JsonOutputTest extends \unittest\TestCase {
   #  ['""', ''],
   #  ['"Test"', 'Test'],
   #  ['"Test \"the\" west"', 'Test "the" west'],
-  #  ['"\u20acuro"', '€uro'],
   #  ['"Test the \"west\""', 'Test the "west"'],
   #  ['"Test\b"', "Test\x08"],
   #  ['"Test\f"', "Test\x0c"],
@@ -58,6 +57,15 @@ abstract class JsonOutputTest extends \unittest\TestCase {
   #  ['"Test\/"', "Test/"]
   #])]
   public function write_string($expected, $value) {
+    $this->assertEquals($expected, $this->write($value));
+  }
+
+  #[@test, @values([
+  #  ['"\u20acuro"', '€uro'],
+  #  ['"\u00dcbercoder"', 'Übercoder'],
+  #  ['"Poop = \ud83d\udca9"', 'Poop = 💩']
+  #])]
+  public function write_unicode($expected, $value) {
     $this->assertEquals($expected, $this->write($value));
   }
 


### PR DESCRIPTION
## Changes

Fixed encoding and decoding of the following:

| String | JSON | Comment |
| --- | --- | --- |
| Poop = 💩 | `"Poop = \ud83d\udca9"` | _Code points are encoded as 2 units called surrogate pairs_ |

See xp-framework/webservices#1
## Performance

Performance is hit in the sub-millisecond area when comparing `$hex > 0xd800 && $hex < 0xdfff`.

| Dimension | Before | After |
| --- | --- | --- |
| Runtime | 1.473 seconds | 1.478 seconds |
| Iteration | 14.7 ms per iteration, result = 30 | 14.8 ms per iteration, result = 30 |
| Memory | 874.086 kB memory used | 875.523 kB memory used |
| Peak memory | 920.328 kB peak | 921.766 kB peak |

_This is parsing a 158791 bytes JSON file 100 times._
