### PR TITLE
Add support for all traversables to Json::write()

### DIFF
--- a/src/main/php/text/json/Output.class.php
+++ b/src/main/php/text/json/Output.class.php
@@ -22,7 +22,7 @@ abstract class Output extends \lang\Object {
    */
   public function write($value) {
     $f= $this->format;
-    if ($value instanceof \Traversable) {
+    if ($value instanceof \Traversable || is_array($value)) {
       $i= 0;
       $map= null;
       foreach ($value as $key => $element) {
@@ -42,35 +42,6 @@ abstract class Output extends \lang\Object {
         $this->appendToken('[]');
       } else {
         $this->appendToken($map ? '}' : ']');
-      }
-    } else if (is_array($value)) {
-      if (empty($value)) {
-        $this->appendToken('[]');
-      } else if (0 === key($value)) {
-        $next= false;
-        foreach ($value as $element) {
-          if ($next) {
-            $this->appendToken($f->comma);
-          } else {
-            $this->appendToken($f->open('['));
-            $next= true;
-          }
-          $this->write($element);
-        }
-        $this->appendToken($f->close(']'));
-      } else {
-        $next= false;
-        foreach ($value as $key => $mapped) {
-          if ($next) {
-            $this->appendToken($f->comma);
-          } else {
-            $this->appendToken($f->open('{'));
-            $next= true;
-          }
-          $this->appendToken($f->representationOf($key).$f->colon);
-          $this->write($mapped);
-        }
-        $this->appendToken($f->close('}'));
       }
     } else {
       $this->appendToken($f->representationOf($value));

--- a/src/test/php/text/json/unittest/JsonOutputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonOutputTest.class.php
@@ -141,6 +141,21 @@ abstract class JsonOutputTest extends \unittest\TestCase {
     $this->assertEquals($expected, $this->write($write));
   }
 
+  #[@test, @values([
+  #  ['[]', new \ArrayIterator([])],
+  #  ['[1]', new \ArrayIterator([1])],
+  #  ['[1,2]', new \ArrayIterator([1, 2])],
+  #  ['{"key":"value"}', new \ArrayIterator(['key' => 'value'])],
+  #  ['{"a":"v1","b":"v2"}', new \ArrayIterator(['a' => 'v1', 'b' => 'v2'])],
+  #  ['[1,[2,3]]', new \ArrayIterator([1, new \ArrayIterator([2, 3])])],
+  #  ['[1,[2,3]]', [1, new \ArrayIterator([2, 3])]],
+  #  ['{"a":"v1","b":{"c":"v2"}}', new \ArrayIterator(['a' => 'v1', 'b' => new \ArrayIterator(['c' => 'v2'])])],
+  #  ['{"a":"v1","b":{"c":"v2"}}', ['a' => 'v1', 'b' => new \ArrayIterator(['c' => 'v2'])]]
+  #])]
+  public function write_iterable($expected, $write) {
+    $this->assertEquals($expected, $this->write($write));
+  }
+
   #[@test, @expect('lang.IllegalArgumentException')]
   public function cannot_write_closures() {
     $this->write(function() { });

--- a/src/test/php/text/json/unittest/JsonOutputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonOutputTest.class.php
@@ -150,7 +150,9 @@ abstract class JsonOutputTest extends \unittest\TestCase {
   #  ['[1,[2,3]]', new \ArrayIterator([1, new \ArrayIterator([2, 3])])],
   #  ['[1,[2,3]]', [1, new \ArrayIterator([2, 3])]],
   #  ['{"a":"v1","b":{"c":"v2"}}', new \ArrayIterator(['a' => 'v1', 'b' => new \ArrayIterator(['c' => 'v2'])])],
-  #  ['{"a":"v1","b":{"c":"v2"}}', ['a' => 'v1', 'b' => new \ArrayIterator(['c' => 'v2'])]]
+  #  ['{"a":"v1","b":{"c":"v2"}}', ['a' => 'v1', 'b' => new \ArrayIterator(['c' => 'v2'])]],
+  #  ['[1,{"key":"value"}]', new \ArrayIterator([1, new \ArrayIterator(['key' => 'value'])])],
+  #  ['{"key":[1,2]}', new \ArrayIterator(['key' => new \ArrayIterator([1, 2])])]
   #])]
   public function write_iterable($expected, $write) {
     $this->assertEquals($expected, $this->write($write));


### PR DESCRIPTION
Example, using `xp-framework/rdbms`:

``` php
$json->write($db->query('select * from ...'));
```

See also http://php.net/traversable
