### PR TITLE
Add reset() operation

### DIFF
--- a/src/main/php/text/json/Elements.class.php
+++ b/src/main/php/text/json/Elements.class.php
@@ -23,11 +23,6 @@ class Elements extends \lang\Object implements \Iterator {
   
   /** @return void */
   public function rewind() {
-    if (null === $this->id) {
-      $this->input->reset();
-      $this->id= 0;
-    }
-
     $token= $this->input->firstToken();
     if ('[' === $token) {
       $token= $this->input->nextToken();

--- a/src/main/php/text/json/Elements.class.php
+++ b/src/main/php/text/json/Elements.class.php
@@ -9,7 +9,7 @@ use lang\FormatException;
  */
 class Elements extends \lang\Object implements \Iterator {
   protected $input;
-  protected $id= null;
+  protected $id= 0;
   protected $current= null;
 
   /**
@@ -23,6 +23,11 @@ class Elements extends \lang\Object implements \Iterator {
   
   /** @return void */
   public function rewind() {
+    if (null === $this->id) {
+      $this->input->reset();
+      $this->id= 0;
+    }
+
     $token= $this->input->firstToken();
     if ('[' === $token) {
       $token= $this->input->nextToken();
@@ -30,7 +35,6 @@ class Elements extends \lang\Object implements \Iterator {
         $this->id= $this->end();
       } else {
         $this->current= $this->input->valueOf($token);
-        $this->id= 0;
       }
     } else {
       $this->id= $this->end();

--- a/src/main/php/text/json/FileInput.class.php
+++ b/src/main/php/text/json/FileInput.class.php
@@ -33,6 +33,17 @@ class FileInput extends StreamInput {
     parent::__construct($this->file->getInputStream(), $encoding);
   }
 
+  /**
+   * Resets input
+   *
+   * @return void
+   * @throws io.IOException If this input cannot be reset
+   */
+  public function reset() {
+    $this->wasOpen || $this->file->open(File::READ);
+    parent::reset();
+  }
+
   /** @return void */
   public function close() {
     if (!$this->wasOpen && $this->file->isOpen()) {

--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -13,7 +13,7 @@ abstract class Input extends \lang\Object {
   protected $len;
   protected $pos;
   protected $encoding;
-  protected $firstToken= null, $elements= null, $pairs= null;
+  protected $firstToken= null;
 
   protected static $escapes= [
     '"'  => "\"",
@@ -239,10 +239,7 @@ abstract class Input extends \lang\Object {
    * @return php.Iterator
    */
   public function elements() {
-    if (null === $this->elements) {
-      $this->elements= new Elements($this);
-    }
-    return $this->elements;
+    return new Elements($this);
   }
 
   /**
@@ -251,10 +248,7 @@ abstract class Input extends \lang\Object {
    * @return php.Iterator
    */
   public function pairs() {
-    if (null === $this->pairs) {
-      $this->pairs= new Pairs($this);
-    }
-    return $this->pairs;
+    return new Pairs($this);
   }
 
   /** @return void */

--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -133,6 +133,7 @@ abstract class Input extends \lang\Object {
    * Resets input
    *
    * @return void
+   * @throws io.IOException If this input cannot be reset
    */
   public abstract function reset();
 

--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -13,7 +13,7 @@ abstract class Input extends \lang\Object {
   protected $len;
   protected $pos;
   protected $encoding;
-  protected $firstToken= null;
+  protected $firstToken= null, $elements= null, $pairs= null;
 
   protected static $escapes= [
     '"'  => "\"",
@@ -130,6 +130,13 @@ abstract class Input extends \lang\Object {
   }
 
   /**
+   * Resets input
+   *
+   * @return void
+   */
+  public abstract function reset();
+
+  /**
    * Returns first token
    *
    * @return string
@@ -232,7 +239,10 @@ abstract class Input extends \lang\Object {
    * @return php.Iterator
    */
   public function elements() {
-    return new Elements($this);
+    if (null === $this->elements) {
+      $this->elements= new Elements($this);
+    }
+    return $this->elements;
   }
 
   /**
@@ -241,7 +251,10 @@ abstract class Input extends \lang\Object {
    * @return php.Iterator
    */
   public function pairs() {
-    return new Pairs($this);
+    if (null === $this->pairs) {
+      $this->pairs= new Pairs($this);
+    }
+    return $this->pairs;
   }
 
   /** @return void */

--- a/src/main/php/text/json/MultiByteSource.class.php
+++ b/src/main/php/text/json/MultiByteSource.class.php
@@ -1,10 +1,11 @@
 <?php namespace text\json;
 
 use io\streams\InputStream;
+use io\streams\Seekable;
 use io\streams\Streams;
 use io\IOException;
 
-class MultiByteSource extends \lang\Object implements InputStream {
+class MultiByteSource extends \lang\Object implements InputStream, Seekable {
   protected $in= null;
 
   /**
@@ -27,6 +28,30 @@ class MultiByteSource extends \lang\Object implements InputStream {
    */
   public function available() {
     return $this->in->available();
+  }
+
+  /**
+   * Seek
+   *
+   * @param  int $offset
+   * @param  int $whence
+   * @return void
+   */
+  public function seek($offset, $whence= SEEK_SET) {
+    if ($this->in instanceof Seekable) {
+      $this->in->seek($offset, $whence);
+    } else {
+      throw new IOException('Cannot seek '.$this->in->toString());
+    }
+  }
+
+  /**
+   * Tell
+   *
+   * @return int
+   */
+  public function tell() {
+    return $this->in->tell();
   }
 
   /**

--- a/src/main/php/text/json/Pairs.class.php
+++ b/src/main/php/text/json/Pairs.class.php
@@ -9,7 +9,7 @@ use lang\FormatException;
  */
 class Pairs extends \lang\Object implements \Iterator {
   protected $input;
-  protected $key= null;
+  protected $key= true;
   protected $value= null;
 
   /**
@@ -38,6 +38,10 @@ class Pairs extends \lang\Object implements \Iterator {
   
   /** @return void */
   public function rewind() {
+    if (null === $this->key) {
+      $this->input->reset();
+    }
+
     $token= $this->input->firstToken();
     if ('{' === $token) {
       $token= $this->input->nextToken();

--- a/src/main/php/text/json/Pairs.class.php
+++ b/src/main/php/text/json/Pairs.class.php
@@ -9,7 +9,7 @@ use lang\FormatException;
  */
 class Pairs extends \lang\Object implements \Iterator {
   protected $input;
-  protected $key= true;
+  protected $key= null;
   protected $value= null;
 
   /**
@@ -38,10 +38,6 @@ class Pairs extends \lang\Object implements \Iterator {
   
   /** @return void */
   public function rewind() {
-    if (null === $this->key) {
-      $this->input->reset();
-    }
-
     $token= $this->input->firstToken();
     if ('{' === $token) {
       $token= $this->input->nextToken();

--- a/src/main/php/text/json/StreamInput.class.php
+++ b/src/main/php/text/json/StreamInput.class.php
@@ -1,6 +1,8 @@
 <?php namespace text\json;
 
 use io\streams\InputStream;
+use io\streams\Seekable;
+use io\IOException;
 use lang\FormatException;
 
 /**
@@ -14,7 +16,7 @@ use lang\FormatException;
  * @test  xp://text.json.unittest.StreamInputTest
  */
 class StreamInput extends Input {
-  protected $in;
+  protected $in, $offset;
 
   /**
    * Creates a new instance
@@ -28,20 +30,41 @@ class StreamInput extends Input {
     if ("\376\377" === $bom) {
       $encoding= \xp::ENCODING;
       $this->in= new MultiByteSource($in, 'utf-16be');
+      $this->offset= 2;
     } else if ("\377\376" === $bom) {
       $encoding= \xp::ENCODING;
       $this->in= new MultiByteSource($in, 'utf-16le');
+      $this->offset= 2;
     } else {
       $bom.= $in->read(1);
       if ("\357\273\277" === $bom) {
         $encoding= 'utf-8';
+        $this->offset= 3;
       } else {
         $initial= $bom;
+        $this->offset= 0;
       }
       $this->in= $in;
     }
 
     parent::__construct($initial.$this->in->read(), $encoding);
+  }
+
+  /**
+   * Resets input
+   *
+   * @return void
+   */
+  public function reset() {
+    if ($this->in instanceof Seekable) {
+      $this->in->seek($this->offset);
+      $this->bytes= $this->in->read();
+      $this->len= strlen($this->bytes);
+      $this->pos= 0;
+      $this->firstToken= null;
+    } else {
+      throw new IOException('Cannot seek '.$this->in->toString());
+    }
   }
 
   /**

--- a/src/main/php/text/json/StreamInput.class.php
+++ b/src/main/php/text/json/StreamInput.class.php
@@ -54,6 +54,7 @@ class StreamInput extends Input {
    * Resets input
    *
    * @return void
+   * @throws io.IOException If this input cannot be reset
    */
   public function reset() {
     if ($this->in instanceof Seekable) {

--- a/src/main/php/text/json/StringInput.class.php
+++ b/src/main/php/text/json/StringInput.class.php
@@ -18,6 +18,7 @@ class StringInput extends Input {
    * Resets input
    *
    * @return void
+   * @throws io.IOException If this input cannot be reset
    */
   public function reset() {
     $this->pos= 0;

--- a/src/main/php/text/json/StringInput.class.php
+++ b/src/main/php/text/json/StringInput.class.php
@@ -15,6 +15,16 @@ use lang\FormatException;
 class StringInput extends Input {
 
   /**
+   * Resets input
+   *
+   * @return void
+   */
+  public function reset() {
+    $this->pos= 0;
+    $this->firstToken= null;
+  }
+
+  /**
    * Returns next token
    *
    * @return string

--- a/src/test/php/text/json/unittest/FileInputTest.class.php
+++ b/src/test/php/text/json/unittest/FileInputTest.class.php
@@ -68,7 +68,7 @@ class FileInputTest extends JsonInputTest {
   public function is_closed_after_elements() {
     $file= $this->fileWith('[]', File::WRITE);
     $file->close();
-    (new FileInput($file))->elements();
+    iterator_to_array((new FileInput($file))->elements());
     $this->assertFalse($file->isOpen());
   }
 
@@ -76,7 +76,7 @@ class FileInputTest extends JsonInputTest {
   public function is_closed_after_pairs() {
     $file= $this->fileWith('{}', File::WRITE);
     $file->close();
-    (new FileInput($file))->elements();
+    iterator_to_array((new FileInput($file))->pairs());
     $this->assertFalse($file->isOpen());
   }
 

--- a/src/test/php/text/json/unittest/FileInputTest.class.php
+++ b/src/test/php/text/json/unittest/FileInputTest.class.php
@@ -87,4 +87,14 @@ class FileInputTest extends JsonInputTest {
     (new FileInput($file))->read();
     $this->assertTrue($file->isOpen());
   }
+
+  #[@test]
+  public function is_reopened_when_reset() {
+    $file= $this->fileWith('{}', File::WRITE);
+    $file->close();
+    $input= new FileInput($file);
+    $input->read();
+    $input->reset();
+    $this->assertTrue($file->isOpen());
+  }
 }

--- a/src/test/php/text/json/unittest/JsonInputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonInputTest.class.php
@@ -533,13 +533,6 @@ abstract class JsonInputTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function calling_elements_twice() {
-    $input= $this->input('[1]');
-    $this->assertEquals([1], iterator_to_array($input->elements()), '#1');
-    $this->assertEquals([1], iterator_to_array($input->elements()), '#2');
-  }
-
-  #[@test]
   public function pairs_after_detecting_type() {
     $input= $this->input('{"key" : "value"}');
     $input->type();
@@ -554,9 +547,26 @@ abstract class JsonInputTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function calling_pairs_twice() {
+  public function calling_read_after_resetting() {
+    $input= $this->input('[1]');
+    $this->assertEquals([1], $input->read(), '#1');
+    $input->reset();
+    $this->assertEquals([1], $input->read(), '#2');
+  }
+
+  #[@test]
+  public function calling_elements_after_resetting() {
+    $input= $this->input('[1]');
+    $this->assertEquals([1], iterator_to_array($input->elements()), '#1');
+    $input->reset();
+    $this->assertEquals([1], iterator_to_array($input->elements()), '#2');
+  }
+
+  #[@test]
+  public function calling_pairs_after_resetting() {
     $input= $this->input('{"key" : "value"}');
     $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#1');
+    $input->reset();
     $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#2');
   }
 }

--- a/src/test/php/text/json/unittest/JsonInputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonInputTest.class.php
@@ -533,6 +533,13 @@ abstract class JsonInputTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function calling_elements_twice() {
+    $input= $this->input('[1]');
+    $this->assertEquals([1], iterator_to_array($input->elements()), '#1');
+    $this->assertEquals([1], iterator_to_array($input->elements()), '#2');
+  }
+
+  #[@test]
   public function pairs_after_detecting_type() {
     $input= $this->input('{"key" : "value"}');
     $input->type();
@@ -544,5 +551,12 @@ abstract class JsonInputTest extends \unittest\TestCase {
     $input= $this->input('{"key" : "value"}');
     iterator_to_array($input->pairs());
     $this->assertEquals(Types::$OBJECT, $input->type());
+  }
+
+  #[@test]
+  public function calling_pairs_twice() {
+    $input= $this->input('{"key" : "value"}');
+    $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#1');
+    $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#2');
   }
 }

--- a/src/test/php/text/json/unittest/StreamInputTest.class.php
+++ b/src/test/php/text/json/unittest/StreamInputTest.class.php
@@ -2,6 +2,8 @@
 
 use text\json\StreamInput;
 use io\streams\MemoryInputStream;
+use io\streams\InputStream;
+use io\IOException;
 
 /**
  * Tests the StreamInput implementation
@@ -32,5 +34,45 @@ class StreamInputTest extends JsonInputTest {
   #[@test]
   public function read_utf_16be_with_bom() {
     $this->assertEquals('Übercoder', $this->read("\376\377\000\"\000\334\000b\000e\000r\000c\000o\000d\000e\000r\000\""));
+  }
+
+  #[@test, @values([
+  #  "[1]",
+  #  "\357\273\277[1]",
+  #  "\377\376[\0001\000]\000",
+  #  "\376\377\000[\0001\000]"
+  #])]
+  public function calling_elements_twice($input) {
+    $input= $this->input($input);
+    $this->assertEquals([1], iterator_to_array($input->elements()), '#1');
+    $this->assertEquals([1], iterator_to_array($input->elements()), '#2');
+  }
+
+  #[@test, @values([
+  #  "{\"key\":\"value\"}",
+  #  "\357\273\277{\"key\":\"value\"}",
+  #  "\377\376{\000\"\000k\000e\000y\000\"\000:\000\"\000v\000a\000l\000u\000e\000\"\000}\000",
+  #  "\376\377\000{\000\"\000k\000e\000y\000\"\000:\000\"\000v\000a\000l\000u\000e\000\"\000}"
+  #])]
+  public function calling_pairs_twice($input) {
+    $input= $this->input($input);
+    $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#1');
+    $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#2');
+  }
+
+  #[@test]
+  public function cannot_reset_unseekable() {
+    $input= new StreamInput(newinstance(InputStream::class, [], [
+      'read'      => function($size= 8192) { return '[1]'; },
+      'available' => function() { return true; },
+      'close'     => function() { }
+    ]));
+    $this->assertEquals([1], iterator_to_array($input->elements()), '#1');
+    try {
+      iterator_to_array($input->elements());
+      $this->fail('Expected exception not caught', null, 'io.IOException');
+    } catch (IOException $expected) {
+      // OK
+    }
   }
 }

--- a/src/test/php/text/json/unittest/StreamInputTest.class.php
+++ b/src/test/php/text/json/unittest/StreamInputTest.class.php
@@ -42,9 +42,23 @@ class StreamInputTest extends JsonInputTest {
   #  "\377\376[\0001\000]\000",
   #  "\376\377\000[\0001\000]"
   #])]
-  public function calling_elements_twice($input) {
+  public function calling_read_after_resetting($input) {
+    $input= $this->input($input);
+    $this->assertEquals([1], $input->read(), '#1');
+    $input->reset();
+    $this->assertEquals([1], $input->read(), '#2');
+  }
+
+  #[@test, @values([
+  #  "[1]",
+  #  "\357\273\277[1]",
+  #  "\377\376[\0001\000]\000",
+  #  "\376\377\000[\0001\000]"
+  #])]
+  public function calling_elements_after_resetting($input) {
     $input= $this->input($input);
     $this->assertEquals([1], iterator_to_array($input->elements()), '#1');
+    $input->reset();
     $this->assertEquals([1], iterator_to_array($input->elements()), '#2');
   }
 
@@ -54,9 +68,10 @@ class StreamInputTest extends JsonInputTest {
   #  "\377\376{\000\"\000k\000e\000y\000\"\000:\000\"\000v\000a\000l\000u\000e\000\"\000}\000",
   #  "\376\377\000{\000\"\000k\000e\000y\000\"\000:\000\"\000v\000a\000l\000u\000e\000\"\000}"
   #])]
-  public function calling_pairs_twice($input) {
+  public function calling_pairs_after_resetting($input) {
     $input= $this->input($input);
     $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#1');
+    $input->reset();
     $this->assertEquals(['key' => 'value'], iterator_to_array($input->pairs()), '#2');
   }
 
@@ -69,6 +84,7 @@ class StreamInputTest extends JsonInputTest {
     ]));
     $this->assertEquals([1], iterator_to_array($input->elements()), '#1');
     try {
+      $input->reset();
       iterator_to_array($input->elements());
       $this->fail('Expected exception not caught', null, 'io.IOException');
     } catch (IOException $expected) {


### PR DESCRIPTION
Enable calling `elements()`, `pairs()` and `read()` again after explicitly resetting the stream. See xp-forge/json#1.

**_Caution**_: _Resetting may cause an IOException if the underlying stream is not seekable, e.g. a socket._
