### PR TITLE
Return `{}` as empty object instead of empty array

### DIFF
--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -92,7 +92,7 @@ abstract class Input implements Value {
   protected function readObject($nesting) {
     $token= $this->nextToken();
     if ('}' === $token) {
-      return [];
+      return (object)[];
     } else if (null !== $token) {
       $result= [];
       if (++$nesting > $this->maximumNesting) {

--- a/src/test/php/text/json/unittest/JsonInputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonInputTest.class.php
@@ -118,7 +118,7 @@ abstract class JsonInputTest {
 
   #[Test, Values(['{}', '{ }'])]
   public function read_empty_object($source) {
-    Assert::equals([], $this->read($source));
+    Assert::equals((object)[], $this->read($source));
   }
 
   #[Test, Values(['{"key": "value"}', '{"key" : "value"}', '{ "key" : "value" }'])]


### PR DESCRIPTION
...and be consistent with emitting empty objects as `{}`.

## Before
Emitting an empty object as JSON after reading it results in it being output as an empty array:

```bash
$ xp -w 'use text\json\Json; Json::of(Json::read("{}"))'
[]

# There is no problem with non-empty objects though!
$ xp -w 'use text\json\Json; Json::of(Json::read("{\"key\":\"value\"}"))'
{"key":"value"}
```

## After
Consistent result:

```bash
$ xp -w 'use text\json\Json; Json::of(Json::read("{}"))'
{}
```

## Potential pitfalls
Objects (even ones without a single property) are never considered empty:

```php
empty([]);         // true
empty((object)[]); // false
```

Also, using sizeof() will raise the following exception: *lang.Error (sizeof(): Argument 1 ($value) must be of type Countable|array, stdClass given)* - similar to all cases where we use type hints; which would then need to be widened to the (ugly-looking) `array|stdClass` to support this.

## See also

* https://www.php.net/manual/en/json.constants.php#constant.json-object-as-array
* https://stackoverflow.com/questions/8595627/best-way-to-create-an-empty-object-in-json-with-php
* https://github.com/FriendsOfSymfony/FOSRestBundle/issues/980

* * * 
⚠️ **Heads up:** This is a BC break and would require a major version release, 6.0 at the time of writing.