### PR TITLE
Return JSON objects in a wrapper object

### DIFF
--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -94,10 +94,11 @@ abstract class Input implements Value {
     if ('}' === $token) {
       return new JsonObject();
     } else if (null !== $token) {
-      $result= [];
       if (++$nesting > $this->maximumNesting) {
         throw new FormatException('Nesting level too deep');
       }
+
+      $result= [];
       do {
         $key= $this->valueOf($token, $nesting);
         if (!is_string($key)) {

--- a/src/main/php/text/json/Input.class.php
+++ b/src/main/php/text/json/Input.class.php
@@ -92,7 +92,7 @@ abstract class Input implements Value {
   protected function readObject($nesting) {
     $token= $this->nextToken();
     if ('}' === $token) {
-      return [];
+      return new JsonObject();
     } else if (null !== $token) {
       $result= [];
       if (++$nesting > $this->maximumNesting) {
@@ -113,7 +113,7 @@ abstract class Input implements Value {
         if (',' === $delim) {
           continue;
         } else if ('}' === $delim) {
-          return $result;
+          return new JsonObject($result);
         } else {
           throw new FormatException('Unexpected '.Objects::stringOf($delim).', expecting "," or "}"');
         }

--- a/src/main/php/text/json/JsonObject.class.php
+++ b/src/main/php/text/json/JsonObject.class.php
@@ -1,0 +1,53 @@
+<?php namespace text\json;
+
+use ArrayAccess, ArrayIterator, Countable, IteratorAggregate, ReturnTypeWillChange;
+use lang\Value;
+use util\Objects;
+
+/** @test text.json.JsonObjectTest */
+class JsonObject implements ArrayAccess, Countable, IteratorAggregate, Value {
+  private $backing;
+
+  /** @param [:var] $backing */
+  public function __construct($backing= []) {
+    $this->backing= $backing;
+  }
+
+  #[ReturnTypeWillChange]
+  public function count() { return sizeof($this->backing); }
+
+  #[ReturnTypeWillChange]
+  public function offsetGet($key) { return $this->backing[$key]; }
+
+  #[ReturnTypeWillChange]
+  public function offsetSet($key, $value) { $this->backing[$key]= $value; }
+
+  #[ReturnTypeWillChange]
+  public function offsetExists($key) { return array_key_exists($key, $this->backing); }
+
+  #[ReturnTypeWillChange]
+  public function offsetUnset($key) { unset($this->backing[$key]); }
+
+  #[ReturnTypeWillChange]
+  public function getIterator() { return new ArrayIterator($this->backing); }
+
+  /** @return string */
+  public function toString() {
+    return '(object)'.Objects::stringOf($this->backing);
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'J'.Objects::hashOf($this->backing);
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->backing, $value->backing) : 1;
+  }
+}

--- a/src/main/php/text/json/JsonObject.class.php
+++ b/src/main/php/text/json/JsonObject.class.php
@@ -23,7 +23,7 @@ class JsonObject implements ArrayAccess, Countable, IteratorAggregate, Value {
   public function offsetSet($key, $value) { $this->backing[$key]= $value; }
 
   #[ReturnTypeWillChange]
-  public function offsetExists($key) { return array_key_exists($key, $this->backing); }
+  public function offsetExists($key) { return isset($this->backing[$key]); }
 
   #[ReturnTypeWillChange]
   public function offsetUnset($key) { unset($this->backing[$key]); }

--- a/src/main/php/text/json/Output.class.php
+++ b/src/main/php/text/json/Output.class.php
@@ -22,30 +22,8 @@ abstract class Output implements Value {
    * @return self
    */
   public function write($value) {
-    $f= $this->format;
-    if ($value instanceof Traversable || is_array($value)) {
-      $i= 0;
-      $map= null;
-      foreach ($value as $key => $element) {
-        if (0 === $i++) {
-          $map= 0 !== $key;
-          $this->appendToken($f->open($map ? '{' : '['));
-        } else {
-          $this->appendToken($f->comma);
-        }
-
-        if ($map) {
-          $this->appendToken($f->representationOf((string)$key).$f->colon);
-        }
-        $this->write($element);
-      }
-      if (null === $map) {
-        $this->appendToken('[]');
-      } else {
-        $this->appendToken($f->close($map ? '}' : ']'));
-      }
-    } else {
-      $this->appendToken($f->representationOf($value));
+    foreach ($this->format->tokensOf($value) as $token) {
+      $this->appendToken($token);
     }
     return $this;
   }

--- a/src/test/php/text/json/unittest/FormatTest.class.php
+++ b/src/test/php/text/json/unittest/FormatTest.class.php
@@ -1,10 +1,21 @@
 <?php namespace text\json\unittest;
 
+use test\{Assert, Before, Test, Values};
 use text\json\Format;
-use test\Assert;
-use test\Test;
 
 abstract class FormatTest {
+  protected $format;
+
+  /** @return iterable */
+  protected function singleTokens() {
+    yield [true, ['true']];
+    yield [false, ['false']];
+    yield [null, ['null']];
+    yield [6100, ['6100']];
+    yield [0.5, ['0.5']];
+    yield ['Test', ['"Test"']];
+    yield [[], ['[]']];
+  }
 
   /**
    * Returns a `Format` instance
@@ -96,4 +107,8 @@ abstract class FormatTest {
   #[Test]
   public abstract function object_with_multiple_pairs();
 
+  #[Test, Values(from: 'singleTokens')]
+  public function iterate_single_tokens($value, $expected) {
+    Assert::equals($expected, iterator_to_array($this->format()->tokensOf($value)));
+  }
 }

--- a/src/test/php/text/json/unittest/JsonInputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonInputTest.class.php
@@ -3,7 +3,7 @@
 use io\streams\MemoryInputStream;
 use lang\FormatException;
 use test\{Assert, Expect, Test, Values};
-use text\json\Types;
+use text\json\{Types, JsonObject};
 use util\collections\Pair;
 
 /**
@@ -118,32 +118,37 @@ abstract class JsonInputTest {
 
   #[Test, Values(['{}', '{ }'])]
   public function read_empty_object($source) {
-    Assert::equals([], $this->read($source));
+    Assert::equals(new JsonObject([]), $this->read($source));
   }
 
   #[Test, Values(['{"key": "value"}', '{"key" : "value"}', '{ "key" : "value" }'])]
   public function read_key_value_pair($source) {
-    Assert::equals(['key' => 'value'], $this->read($source));
+    Assert::equals(new JsonObject(['key' => 'value']), $this->read($source));
   }
 
   #[Test, Values(['{"a": "v1", "b": "v2"}', '{"a" : "v1", "b" : "v2"}', '{ "a" : "v1" , "b" : "v2" }'])]
   public function read_key_value_pairs($source) {
-    Assert::equals(['a' => 'v1', 'b' => 'v2'], $this->read($source));
+    Assert::equals(new JsonObject(['a' => 'v1', 'b' => 'v2']), $this->read($source));
   }
 
   #[Test, Values(['{"": "value"}', '{"" : "value"}', '{ "" : "value" }'])]
   public function empty_key($source) {
-    Assert::equals(['' => 'value'], $this->read($source));
+    Assert::equals(new JsonObject(['' => 'value']), $this->read($source));
   }
 
   #[Test]
   public function keys_overwrite_each_other() {
-    Assert::equals(['key' => 'v2'], $this->read('{"key": "v1", "key": "v2"}'));
+    Assert::equals(new JsonObject(['key' => 'v2']), $this->read('{"key": "v1", "key": "v2"}'));
   }
 
   #[Test]
   public function object_ending_with_zero() {
-    Assert::equals(['key' => 0], $this->read('{"key": 0}'));
+    Assert::equals(new JsonObject(['key' => 0]), $this->read('{"key": 0}'));
+  }
+
+  #[Test]
+  public function array_access() {
+    Assert::equals('value', $this->read('{"key" : "value"}')['key']);
   }
 
   #[Test, Expect(FormatException::class), Values(['{', '{{', '{{}', '}', '}}'])]
@@ -279,11 +284,11 @@ abstract class JsonInputTest {
   #[Test]
   public function indented_json() {
     Assert::equals(
-      [
+      new JsonObject([
         'color' => 'green',
         'sizes' => ['S', 'M', 'L', 'XL'],
         'price' => 12.99
-      ],
+      ]),
       $this->read('{
         "color" : "green",
         "sizes" : [ "S", "M", "L", "XL" ],

--- a/src/test/php/text/json/unittest/JsonObjectTest.class.php
+++ b/src/test/php/text/json/unittest/JsonObjectTest.class.php
@@ -1,0 +1,75 @@
+<?php namespace text\json\unittest;
+
+use lang\IndexOutOfBoundsException;
+use test\{Assert, Test, Values};
+use text\json\JsonObject;
+
+class JsonObjectTest {
+
+  #[Test]
+  public function can_create() {
+    new JsonObject();
+  }
+
+  #[Test, Values([[[]], [['key' => 'value']]])]
+  public function can_create_with($backing) {
+    new JsonObject($backing);
+  }
+
+  #[Test]
+  public function get() {
+    Assert::equals('value', (new JsonObject(['key' => 'value']))['key']);
+  }
+
+  #[Test]
+  public function set() {
+    $fixture= new JsonObject(['key' => 'value']);
+    $fixture['key']= 'changed';
+
+    Assert::equals('changed', $fixture['key']);
+  }
+
+  #[Test]
+  public function isset() {
+    $fixture= new JsonObject(['key' => 'value']);
+
+    Assert::true(isset($fixture['key']));
+    Assert::false(isset($fixture['color']));
+  }
+
+  #[Test]
+  public function unset() {
+    $fixture= new JsonObject(['key' => 'value']);
+    unset($fixture['key']);
+
+    Assert::throws(IndexOutOfBoundsException::class, function() use($fixture) {
+      $fixture['key'];
+    });
+  }
+
+  #[Test, Values([[[]], [['key' => 'value']], [['a' => 0, 'b' => 1]]])]
+  public function iteration($backing) {
+    Assert::equals($backing, iterator_to_array(new JsonObject($backing)));
+  }
+
+  #[Test, Values([[[], 0], [['key' => 'value'], 1], [['a' => 0, 'b' => 1], 2]])]
+  public function count($backing, $expected) {
+    Assert::equals($expected, sizeof(new JsonObject($backing)));
+  }
+
+  #[Test]
+  public function compare() {
+    $a= new JsonObject(['key' => 'value']);
+    $b= new JsonObject(['key' => 'value']);
+    $c= new JsonObject(['key' => 'VALUE']);
+
+    Assert::equals(0, $a->compareTo($b));
+    Assert::equals(1, $a->compareTo($c));
+    Assert::equals(-1, $c->compareTo($a));
+  }
+
+  #[Test, Values([[[], '(object)[]'], [['key' => 'value'], '(object)[key => "value"]']])]
+  public function string_representation($backing, $expected) {
+    Assert::equals($expected, (new JsonObject($backing))->toString());
+  }
+}

--- a/src/test/php/text/json/unittest/JsonObjectTest.class.php
+++ b/src/test/php/text/json/unittest/JsonObjectTest.class.php
@@ -22,6 +22,11 @@ class JsonObjectTest {
   }
 
   #[Test]
+  public function null_coalesce() {
+    Assert::equals('default', (new JsonObject())['key'] ?? 'default');
+  }
+
+  #[Test]
   public function set() {
     $fixture= new JsonObject(['key' => 'value']);
     $fixture['key']= 'changed';
@@ -31,9 +36,10 @@ class JsonObjectTest {
 
   #[Test]
   public function isset() {
-    $fixture= new JsonObject(['key' => 'value']);
+    $fixture= new JsonObject(['key' => 'value', 'price' => null]);
 
     Assert::true(isset($fixture['key']));
+    Assert::false(isset($fixture['price']));
     Assert::false(isset($fixture['color']));
   }
 

--- a/src/test/php/text/json/unittest/JsonObjectTest.class.php
+++ b/src/test/php/text/json/unittest/JsonObjectTest.class.php
@@ -23,7 +23,8 @@ class JsonObjectTest {
 
   #[Test]
   public function null_coalesce() {
-    Assert::equals('default', (new JsonObject())['key'] ?? 'default');
+    $fixture= new JsonObject();
+    Assert::equals('default', $fixture['key'] ?? 'default');
   }
 
   #[Test]

--- a/src/test/php/text/json/unittest/JsonOutputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonOutputTest.class.php
@@ -117,8 +117,13 @@ abstract class JsonOutputTest {
   }
 
   #[Test]
-  public function write_json_object() {
+  public function write_empty_json_object() {
     Assert::equals('{}', $this->write(new JsonObject()));
+  }
+
+  #[Test]
+  public function write_json_object() {
+    Assert::equals('{"key":"value"}', $this->write(new JsonObject(['key' => 'value'])));
   }
 
   #[Test]

--- a/src/test/php/text/json/unittest/JsonOutputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonOutputTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\IllegalArgumentException;
 use test\{Assert, After, Before, Expect, Test, Values};
-use text\json\Types;
+use text\json\{Types, JsonObject};
 
 abstract class JsonOutputTest {
   private static $precision;
@@ -117,13 +117,18 @@ abstract class JsonOutputTest {
   }
 
   #[Test]
+  public function write_json_object() {
+    Assert::equals('{}', $this->write(new JsonObject()));
+  }
+
+  #[Test]
   public function write_array_as_object() {
-    Assert::equals('{0:1,1:2,2:3}', $this->write((object)[1, 2, 3]));
+    Assert::equals('{"0":1,"1":2,"2":3}', $this->write((object)[1, 2, 3]));
   }
 
   #[Test]
   public function write_nested_array_as_object() {
-    Assert::equals('{"values":{0:1,1:2,2:3}}', $this->write(['values' => (object)[1, 2, 3]]));
+    Assert::equals('{"values":{"0":1,"1":2,"2":3}}', $this->write(['values' => (object)[1, 2, 3]]));
   }
 
   #[Test]

--- a/src/test/php/text/json/unittest/JsonTest.class.php
+++ b/src/test/php/text/json/unittest/JsonTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace text\json\unittest;
 
 use lang\FormatException;
-use text\json\{Format, Json, StringInput, StringOutput};
 use test\Assert;
 use test\{Expect, Test};
+use text\json\{Format, Json, StringInput, StringOutput};
 
 class JsonTest {
 
@@ -40,5 +40,10 @@ class JsonTest {
   #[Test]
   public function of_string_with_format() {
     Assert::equals('"Test"', Json::of('Test', Format::$DEFAULT));
+  }
+
+  #[Test]
+  public function object_roundtrip() {
+    Assert::equals('{}', Json::of(Json::read('{}')));
   }
 }

--- a/src/test/php/text/json/unittest/WrappedFormatTest.class.php
+++ b/src/test/php/text/json/unittest/WrappedFormatTest.class.php
@@ -1,8 +1,7 @@
 <?php namespace text\json\unittest;
 
+use test\{Assert, Test};
 use text\json\{StringOutput, WrappedFormat};
-use test\Assert;
-use test\Test;
 
 class WrappedFormatTest extends FormatTest {
 


### PR DESCRIPTION
This pull request changes JSON objects to be returned as an instance of `text.json.JsonObject` instead of as an associative array.

## In a nutshell

```php
use text\json\Json;

$empty= Json::read('{}');                // JsonObject([])
$value= Json::read('{"key" : "value"}'); // JsonObject(['key' => 'value'])
```

This makes us able to distinguish `{}` from `[]`, which previously would have both yielded an empty array:

```php
use text\json\Json;

$roundtrip= Json::of(Json::read('{}'));  // Before: '[]' (❌), After: '{}' (✅)
```

## Decision to create dedicated class

We could have used *StdClass* like `json_decode()` does but would break BC as array access does not work, yielding *Cannot use object of type stdClass as array*.

```php
use text\json\Json;

$value= Json::read('{"color" : "green"}');

// All of the following would have been broken, throwing exceptions 💣
isset($value['color']);
unset($value['color']);
$color= $value['color'];
$n= sizeof($value);
```

There is, however, still some BC breaks. If you pass the returned value to a function with an *array* type hint, use the `+` operator for a union, use `is_array()`, any of the array functions or rely on an assignment creating a copy, or if you use `empty()`, the behavior will be different!
