### PR TITLE
Integrate new io.Blob class

### DIFF
--- a/src/main/php/text/json/Format.class.php
+++ b/src/main/php/text/json/Format.class.php
@@ -1,6 +1,7 @@
 <?php namespace text\json;
 
 use StdClass, Traversable;
+use io\Blob;
 use lang\{IllegalArgumentException, Value};
 
 /**
@@ -9,9 +10,9 @@ use lang\{IllegalArgumentException, Value};
  * @test  text.json.unittest.FormatFactoryTest
  */
 abstract class Format implements Value {
-  const ESCAPE_SLASHES = -65;  // ~JSON_UNESCAPED_SLASHES
-  const ESCAPE_UNICODE = -257; // ~JSON_UNESCAPED_UNICODE
-  const ESCAPE_ENTITIES = 11;  // JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT
+  const ESCAPE_SLASHES= -65;  // ~JSON_UNESCAPED_SLASHES
+  const ESCAPE_UNICODE= -257; // ~JSON_UNESCAPED_UNICODE
+  const ESCAPE_ENTITIES= 11;  // JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT
 
   public static $DEFAULT;
   public $comma, $colon, $options;
@@ -130,8 +131,14 @@ abstract class Format implements Value {
       yield 'true';
     } else if (false === $value) {
       yield 'false';
-    } else if ($value instanceof JsonObject || $value instanceof StdClass) {
+    } else if ($value instanceof StdClass) {
       goto map;
+    } else if ($value instanceof Blob) {
+      yield '"';
+      foreach ($value as $bytes) {
+        yield substr(json_encode($bytes), 1, -1);
+      }
+      yield '"';
     } else if ($value instanceof Traversable) {
       $i= 0;
       $map= null;

--- a/src/test/php/text/json/unittest/JsonOutputTest.class.php
+++ b/src/test/php/text/json/unittest/JsonOutputTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace text\json\unittest;
 
 use ArrayIterator;
+use io\Blob;
 use lang\IllegalArgumentException;
 use test\{Assert, After, Before, Expect, Test, Values};
 use text\json\Types;
@@ -53,6 +54,16 @@ abstract class JsonOutputTest {
   private function generators() {
     yield ['[1,2]', function() { yield 1; yield 2; }];
     yield ['{"key":"value"}', function() { yield 'key' => 'value'; }];
+  }
+
+  /** @return iterable */
+  private function blobs() {
+    yield ['""', new Blob()];
+    yield ['"Test"', new Blob(['Test'])];
+    yield ['"Test \"the\" west"', new Blob(['Test', ' "the" ', 'west'])];
+    yield ['"Test\t"', new Blob(['Test', "\t"])];
+    yield ['"Tested"', new Blob(['Test', 'ed'])];
+    yield ['"Tested"', new Blob((function() { yield 'Test'; yield 'ed'; })())];
   }
 
   #[Before]
@@ -145,6 +156,17 @@ abstract class JsonOutputTest {
   #[Test, Values(from: 'generators')]
   public function write_generator($expected, $write) {
     Assert::equals($expected, $this->write($write()));
+  }
+
+  #[Test, Values(from: 'blobs')]
+  public function write_blob($expected, $write) {
+    Assert::equals($expected, $this->write($write));
+  }
+
+  /** @see https://bugs.php.net/bug.php?id=77069 */
+  #[Test, Runtime(php: '>=7.4.14')]
+  public function write_encoded_blob() {
+    Assert::equals('"VGVzdA=="', $this->write((new Blob('Test'))->encoded('convert.base64-encode')));
   }
 
   #[Test, Expect(IllegalArgumentException::class)]


### PR DESCRIPTION
This pull request integrates the new `io.Blob` class into the JSON output layer.

### Example

```php
use io\Blob;
use text\json\Json;
use util\cmd\Console;

$in= Console::$in->stream();
$out= Console::$out->stream();

// This writes the data while reading it
Json::write(['data' => new Blob($in)], $out);
```